### PR TITLE
Bitbucket cloud support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ For example: `http://bitbucket.local`
 * `git`: *Required*. configuration is based on the [Git
 resource](https://github.com/concourse/git-resource). The `branch` configuration
 from the original resource is ignored.
+* `bitbucket_type`: *Optional*. `cloud` for BitBucket Cloud or `server` for a self-hosted BitBucket Server. `default: server`
+* `dir`: *Optional*. set to name of the resource if resource name is different than repository name
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,31 @@ resources:
     git:
       uri: https://github.com/zarplata/concourse-git-bitbucket-pr-resource
       private_key: {{git-repo-key}}
+
+jobs:
+  - name: my build
+    plan:    
+      - get: my-repo-with-pull-requests
+        trigger: true
+        version: every
+      - task: unit test
+          ...
+          inputs:          
+            - name: my-repo-with-pull-requests
+          run:
+          ...
+        on_failure:
+          put: my-repo-with-pull-requests
+          params:
+            state: FAILED
+            name: "unit test"
+            url: "http://acme.com/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+        on_success:
+          put: my-repo-with-pull-requests
+          params:
+            state: SUCCESSFUL
+            name: "unit test"
+            url: "http://acme.com/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"      
 ```
 
 ## Behavior

--- a/assets/check
+++ b/assets/check
@@ -50,7 +50,7 @@ if [[ "$bitbucket_type" == "server" ]]; then
         | map(select(.updated_at >= '$version_updated_at'))
         | sort_by(.updated_at)' >&3
 elif [[ "$bitbucket_type" == "cloud" ]]; then
-    uri="${base_url}/api/2.0/repositories/${project}/${repository}/pullrequests?limit=${limit}&state=open"
+    uri="${base_url}/api/2.0/repositories/${project}/${repository}/pullrequests?limit=${limit}&state=OPEN"
 
     curl -s --fail -u ${username}:${password} $uri | jq -r \
         '.values

--- a/assets/check
+++ b/assets/check
@@ -12,6 +12,7 @@ payload=$(mktemp /tmp/resource.XXXXXX)
 cat > ${payload} <&0
 
 # source
+bitbucket_type=`jq -r '.source.bitbucket_type // "server"' < ${payload}`
 base_url=`jq -r '.source.base_url // ""' < ${payload}`
 username=`jq -r '.source.username // ""' < ${payload}`
 password=`jq -r '.source.password // ""' < ${payload}`
@@ -34,16 +35,32 @@ if [[ ! ${repository} ]]; then
     exit 1
 fi
 
-uri="${base_url}/rest/api/1.0/projects/${project}/repos/${repository}/pull-requests?limit=${limit}&state=open"
+# Bitbucket Cloud and (self-hosted) Server APIs are a bit different
+if [[ "$bitbucket_type" == "server" ]]; then
+    uri="${base_url}/rest/api/1.0/projects/${project}/repos/${repository}/pull-requests?limit=${limit}&state=open"
 
-curl -s --fail -u ${username}:${password} $uri | jq -r \
-    '.values
-    | map({
-          id: .id | tostring, 
-          branch: .fromRef.id | tostring | (capture("refs/heads/(?<branch>.+)").branch // .),
-          commit: .fromRef.latestCommit, 
-          updated_at: .updatedDate | tostring
-      }) 
-    | map(select(.updated_at >= '$version_updated_at'))
-    | sort_by(.updated_at)' >&3
+    curl -s --fail -u ${username}:${password} $uri | jq -r \
+        '.values
+        | map({
+            id: .id | tostring, 
+            branch: .fromRef.id | tostring | (capture("refs/heads/(?<branch>.+)").branch // .),
+            commit: .fromRef.latestCommit, 
+            updated_at: .updatedDate | tostring
+        }) 
+        | map(select(.updated_at >= '$version_updated_at'))
+        | sort_by(.updated_at)' >&3
+elif [[ "$bitbucket_type" == "cloud" ]]; then
+    uri="${base_url}/api/2.0/repositories/${project}/${repository}/pullrequests?limit=${limit}&state=open"
+
+    curl -s --fail -u ${username}:${password} $uri | jq -r \
+        '.values
+        | map({
+            id: .id | tostring, 
+            branch: .source.branch.name | tostring,
+            commit: .source.commit.hash, 
+            updated_at: .updated_on | tostring
+        }) 
+        | map(select(.updated_at >= "$version_updated_at"))
+        | sort_by(.updated_at)' >&3
+fi
 

--- a/assets/check
+++ b/assets/check
@@ -52,15 +52,25 @@ if [[ "$bitbucket_type" == "server" ]]; then
 elif [[ "$bitbucket_type" == "cloud" ]]; then
     uri="${base_url}/api/2.0/repositories/${project}/${repository}/pullrequests?limit=${limit}&state=OPEN"
 
-    curl -s --fail -u ${username}:${password} $uri | jq -r \
-        '.values
-        | map({
-            id: .id | tostring, 
-            branch: .source.branch.name | tostring,
-            commit: .source.commit.hash, 
-            updated_at: .updated_on | tostring
-        }) 
-        | map(select(.updated_at >= "$version_updated_at"))
-        | sort_by(.updated_at)' >&3
+    # write response to file as feeding it to jq from a variable doesnt work properly: JSON looses linefeed format in variable
+    response=$(mktemp /tmp/resource.XXXXXX)
+    curl -s --fail -u "${username}:${password}" $uri | jq -r '.values' > "${response}"
+
+    prs="[]"
+    while read -r pullrequest; do
+        branch=$(echo "$pullrequest" | jq -r '.source.branch.name')
+        id=$(echo "$pullrequest" | jq -r '.id')
+        commit=$(echo "$pullrequest" | jq -r '.source.commit.hash')
+        commit_url=$(echo "$pullrequest" | jq -r '.source.commit.links.self.href')
+
+        # get the commit date, which is when the PR last got updated code-wise.
+        # the updated_on field in the PR also changes when comment added etc
+        date=$(curl -s --fail -u "${username}:${password}" $commit_url | jq -r '.date')        
+        
+        prs+="+ [{id:\"$id\", branch: \"$branch\", commit:\"$commit\", updated_at:\"$date\"}]"
+    done < <(jq -c '.[]' "${response}")
+
+    # take the list of PRs | sort by update-date of commits | remove the date | pick latest PR, wrap as array for concourse
+    jq -n "[ $prs | sort_by(.updated_at) | map(del(.updated_at)) | .[-1] ]" >&3
 fi
 

--- a/assets/in
+++ b/assets/in
@@ -12,6 +12,7 @@ payload=$(mktemp /tmp/resource.XXXXXX)
 cat > "${payload}" <&0
 
 # source
+bitbucket_type=`jq -r '.source.bitbucket_type // "server"' < ${payload}`
 base_url=`jq -r '.source.base_url // ""' < ${payload}`
 username=`jq -r '.source.username // ""' < ${payload}`
 password=`jq -r '.source.password // ""' < ${payload}`
@@ -40,7 +41,11 @@ if [[ ! ${git} ]]; then
     exit 1
 fi
 
-uri="{$base_url}/rest/api/1.0/projects/${project}/repos/${repository}/pull-requests/${version_id}"
+if [[ "$bitbucket_type" == "server" ]]; then
+    uri="{$base_url}/rest/api/1.0/projects/${project}/repos/${repository}/pull-requests/${version_id}"
+elif [[ "$bitbucket_type" == "cloud" ]]; then
+    uri="${base_url}/api/2.0/repositories/${project}/${repository}/pullrequests/${version_id}"
+fi
 pr=`curl -s --fail -u ${username}:${password} $uri`
 
 git_payload=`echo ${git} | jq --argjson version "${version}" '
@@ -52,28 +57,56 @@ echo $git_payload | /opt/git-resource/in ${resource_path} 1>/dev/null
 # exclude pull-request-info from git index
 echo "pull-request-info" > ${resource_path}/.git/info/exclude
 
-jq -n --argjson version "${version}" --argjson pr "${pr}" '{
-        id: $pr.id,
-        author: {
-            name: $pr.author.user.name,
-            email: $pr.author.user.emailAddress,
-            fullname: $pr.author.user.displayName,
-        },
-        commit: $version.commit,
-        feature_branch: $version.branch,
-        title: $pr.title,
-        upstream_branch: $pr.toRef.id,
-        url: $pr.links.self[0].href,
-        updated_at: $version.updated_at
-    }' > pull-request-info
+# Bitbucket Cloud and (self-hosted) Server APIs are a bit different
+if [[ "$bitbucket_type" == "server" ]]; then
+    jq -n --argjson version "${version}" --argjson pr "${pr}" '{
+            id: $pr.id,
+            author: {
+                name: $pr.author.user.name,
+                email: $pr.author.user.emailAddress,
+                fullname: $pr.author.user.displayName,
+            },
+            commit: $version.commit,
+            feature_branch: $version.branch,
+            title: $pr.title,
+            upstream_branch: $pr.toRef.id,
+            url: $pr.links.self[0].href,
+            updated_at: $version.updated_at
+        }' > pull-request-info
 
-jq -n --argjson version "${version}" --argjson pr "${pr}" '{
-        version: $version, 
-        metadata: [
-            {name: "url", value: $pr.links.self[0].href},
-            {name: "author", value: $pr.author.user.displayName}, 
-            {name: "commit", value: $version.commit},
-            {name: "feature-branch", value: $version.branch},
-            {name: "upstream-branch", value: $pr.toRef.id}
-        ]
-    }' >&3
+    jq -n --argjson version "${version}" --argjson pr "${pr}" '{
+            version: $version, 
+            metadata: [
+                {name: "url", value: $pr.links.self[0].href},
+                {name: "author", value: $pr.author.user.displayName}, 
+                {name: "commit", value: $version.commit},
+                {name: "feature-branch", value: $version.branch},
+                {name: "upstream-branch", value: $pr.toRef.id}
+            ]
+        }' >&3
+elif [[ "$bitbucket_type" == "cloud" ]]; then
+    jq -n --argjson version "${version}" --argjson pr "${pr}" '{
+            id: $pr.id,
+            author: {
+                name: $pr.author.username,
+                fullname: $pr.author.display_name,
+            },
+            commit: $version.commit,
+            feature_branch: $version.branch,
+            title: $pr.title,
+            upstream_branch: $pr.destination.branch.name,
+            url: $pr.links.html.href,
+            updated_at: $version.updated_at
+        }' > pull-request-info
+
+    jq -n --argjson version "${version}" --argjson pr "${pr}" '{
+            version: $version, 
+            metadata: [
+                {name: "url", value: $pr.links.html.href},
+                {name: "author", value: $pr.author.display_name}, 
+                {name: "commit", value: $version.commit},
+                {name: "feature-branch", value: $version.branch},
+                {name: "upstream-branch", value: $pr.destination.branch.name}
+            ]
+        }' >&3
+fi        

--- a/assets/in
+++ b/assets/in
@@ -96,17 +96,19 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
             title: $pr.title,
             upstream_branch: $pr.destination.branch.name,
             url: $pr.links.html.href,
-            updated_at: $version.updated_at
+            updated_at: $pr.created_on
         }' > pull-request-info
 
     jq -n --argjson version "${version}" --argjson pr "${pr}" '{
             version: $version, 
             metadata: [
+                {name: "title", value: $pr.title},
                 {name: "url", value: $pr.links.html.href},
                 {name: "author", value: $pr.author.display_name}, 
                 {name: "commit", value: $version.commit},
                 {name: "feature-branch", value: $version.branch},
-                {name: "upstream-branch", value: $pr.destination.branch.name}
+                {name: "upstream-branch", value: $pr.destination.branch.name},
+                {name: "pullrequest updated", value: $pr.updated_on}
             ]
         }' >&3
 fi        

--- a/assets/out
+++ b/assets/out
@@ -12,12 +12,14 @@ payload=$(mktemp /tmp/resource.XXXXXX)
 cat > "${payload}" <&0
 
 # source
+bitbucket_type=`jq -r '.source.bitbucket_type // "server"' < ${payload}`
 base_url=`jq -r '.source.base_url // ""' < ${payload}`
 username=`jq -r '.source.username // ""' < ${payload}`
 password=`jq -r '.source.password // ""' < ${payload}`
+project=`jq -r '.source.project // ""' < ${payload}`
+repository=`jq -r '.source.repository // ""' < ${payload}`
 # params
 build=`jq '.params' < ${payload}`
-repository=`jq -r '.params.repository' < ${payload}`
 
 if [[ ! ${base_url} ]]; then
     echo "error: source.base_url can't be empty"
@@ -28,16 +30,28 @@ cd ${repository}
 
 pr=`cat pull-request-info`
 commit=`echo ${pr} | jq -r '.commit'`
-url="${base_url}/rest/build-status/1.0/commits/${commit}"
 build_url="${ATC_EXTERNAL_URL}/builds/${BUILD_ID}"
+if [[ "$bitbucket_type" == "server" ]]; then
+    url="${base_url}/rest/build-status/1.0/commits/${commit}"
 
-json=`echo "${build}" | jq --arg build_url "${build_url}" --arg id "${BUILD_ID}" '{
-    state: .state,
-    key: .key,
-    name: (.key + "-" + $id),
-    url: $build_url,
-    description: .description|tostring
-}'`
+    json=`echo "${build}" | jq --arg build_url "${build_url}" --arg id "${BUILD_ID}" '{
+        state: .state,
+        key: .key,
+        name: (.key + "-" + $id),
+        url: $build_url,
+        description: .description|tostring
+    }'`    
+elif [[ "$bitbucket_type" == "cloud" ]]; then
+    url="${base_url}/api/2.0/repositories/${project}/${repository}/commit/${commit}/statuses/build"
+
+    json=`echo "${build}" | jq --arg build_url "${build_url}" --arg id "${BUILD_ID}" '{
+        state: .state,
+        key: .key,
+        name: .name,
+        url: .url,
+        description: .description|tostring
+    }'`    
+fi 
 
 curl -s --fail -u ${username}:${password} -H "Content-Type: application/json" -XPOST ${url} -d "${json}"
 

--- a/assets/out
+++ b/assets/out
@@ -18,6 +18,10 @@ username=`jq -r '.source.username // ""' < ${payload}`
 password=`jq -r '.source.password // ""' < ${payload}`
 project=`jq -r '.source.project // ""' < ${payload}`
 repository=`jq -r '.source.repository // ""' < ${payload}`
+dir=`jq -r '.source.dir // ""' < ${payload}`
+if [[ ! ${dir} ]]; then
+    dir=$repository
+fi
 # params
 build=`jq '.params' < ${payload}`
 
@@ -26,7 +30,7 @@ if [[ ! ${base_url} ]]; then
     exit 1
 fi
 
-cd ${repository}
+cd ${dir}
 
 pr=`cat pull-request-info`
 commit=`echo ${pr} | jq -r '.commit'`
@@ -59,7 +63,6 @@ jq -n --argjson pr "${pr}" --argjson pr "${pr}" '{
     version: {
         id: $pr.id|tostring,
         branch: $pr.feature_branch,
-        commit: $pr.commit,
-        updated_at: $pr.updated_at|tostring
+        commit: $pr.commit
     }
 }' >&3

--- a/assets/out
+++ b/assets/out
@@ -48,14 +48,22 @@ if [[ "$bitbucket_type" == "server" ]]; then
 elif [[ "$bitbucket_type" == "cloud" ]]; then
     url="${base_url}/api/2.0/repositories/${project}/${repository}/commit/${commit}/statuses/build"
 
-    json=`echo "${build}" | jq --arg build_url "${build_url}" --arg id "${BUILD_ID}" '{
+
+    # expand variables like $BUILD_ID before passing into JSON
+    name=$(echo "$build"| jq -r '.name')
+    name=$(eval echo $name)
+    desc=$(echo "$build"| jq -r '.description')
+    desc=$(eval echo $desc)
+    build_url=$(echo "$build"| jq -r '.url')
+    build_url=$(eval echo $build_url)
+    json=`echo "${build}" | jq --arg build_url "${build_url}" --arg id "${BUILD_ID}" --arg name "$name" --arg desc "$desc" '{
         state: .state,
-        key: .key,
-        name: .name,
-        url: .url,
-        description: .description|tostring
-    }'`    
-fi 
+        key: ($name + "-" + $id),
+        name: $name,
+        url: $build_url,
+        description: $desc
+    }'` 
+fi
 
 curl -s --fail -u ${username}:${password} -H "Content-Type: application/json" -XPOST ${url} -d "${json}"
 


### PR DESCRIPTION
fixes #1 

@idr0id here is my tested and working support for Bitbucket Cloud. 
it doesnt affect your implementation at all unless you explicitly add `bitbucket_type` to `source` , see updated README

Btw I now solved the `updated_on` problem mentionedn in #1 by getting the PRs latest commit date. 

While developing I found a few problems which likely also affect your Bitbukcket Server support:
in `out` you have 
```
        key: .key,
        name: (.key + "-" + $id),
```
however the `key` should be unique and the name descriptive as its visible in Bitbucket and the `key` is only a hidden unique identifier. so I have 
```
        key: ($name + "-" + $id),
        name: $name,
```
which will result in name from params like `unit test`  and the key being `unit test-140`. if the key isnt unique, Bitbucket wont properly display multiple jobs on same commit, i.e. "unit test" + "build artifacts" + "docker build" 
you have it the other way round 

Second big issue is that PR resource should only output a single version in `check`. i.e. the latest PR. otherwise, if you output *ALL* open PRs, you will get weird behavior like build not triggered, sometimes two builds triggered where one already was build etc. depending on the order you update the PRs with new commits. 
(Outputting only a single (latest) PR is also how other GitHub PR resources do.)

Third issue: metadata like `$BUILD_NAME` etc in params wasnt working. see my comment in `out`

btw, for Bitbucket Server there seem to exist resources. in case you didnt see them
https://github.com/laurentverbruggen/concourse-bitbucket-pullrequest-resource
(thats the one linked in concourse docs, but also misses Bitbucket Cloud support)
https://github.com/thaniyarasu/pullrequest-resource
(seems worth a look, didnt work for Cloud for me)