### PR TITLE
Swapped key value with name value

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -58,7 +58,7 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
     build_url=$(eval echo $build_url)
     json=`echo "${build}" | jq --arg build_url "${build_url}" --arg id "${BUILD_ID}" --arg name "$name" --arg desc "$desc" '{
         state: .state,
-        key: ($name + "-" + $id),
+        key: $name,
         name: $name,
         url: $build_url,
         description: $desc

--- a/assets/out
+++ b/assets/out
@@ -59,7 +59,7 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
     json=`echo "${build}" | jq --arg build_url "${build_url}" --arg id "${BUILD_ID}" --arg name "$name" --arg desc "$desc" '{
         state: .state,
         key: $name,
-        name: $name,
+        name: ($name + "-" + $id),
         url: $build_url,
         description: $desc
     }'` 


### PR DESCRIPTION
This PR addresses the issue reported here: https://github.com/zarplata/concourse-git-bitbucket-pr-resource/issues/13.

By removing the $BUILD_ID from the key, we effectively force Bitbucket to update the status of the existing build reported to the PR rather than reporting a new build status.