### PR TITLE
Use `jq --arg/--argjson` when building JSON objects in assets/check (and other fixes)

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -6,8 +6,6 @@ set -e -o pipefail
 exec 3>&1
 exec 1>&2
 
-cd "${1}"
-
 payload=$(mktemp /tmp/resource.XXXXXX)
 cat > ${payload} <&0
 

--- a/assets/check
+++ b/assets/check
@@ -42,7 +42,7 @@ if [[ "$bitbucket_type" == "server" ]]; then
     [[ "${source_branch}" ]] && branch_param="&at=refs/heads/${source_branch}"
     uri="${base_url}/rest/api/1.0/projects/${project}/repos/${repository}/pull-requests?limit=${limit}&state=open${branch_param}"
 
-    curl -sS --fail -u ${username}:${password} $uri | jq -r \
+    curl -sS --fail -u ${username}:${password} $uri | jq -r --arg version_updated_at "${version_updated_at}" \
         '.values
         | map({
             id: .id | tostring,
@@ -52,7 +52,7 @@ if [[ "$bitbucket_type" == "server" ]]; then
             updated_at: .updatedDate | tostring
         })
         | map(select(if .title | test("wip"; "i") then false else true end))
-        | map(select(.updated_at >= '$version_updated_at'))
+        | map(select(.updated_at >= $version_updated_at))
         | sort_by(.updated_at)' >&3
 elif [[ "$bitbucket_type" == "cloud" ]]; then
     uri="${base_url}/api/2.0/repositories/${project}/${repository}/pullrequests?limit=${limit}&state=OPEN"
@@ -76,16 +76,17 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
         # the updated_on field in the PR also changes when comment added etc
         date=$(curl -s --fail -u "${username}:${password}" $commit_url | jq -r '.date')
 
-        prs+="+ [{id:\"$id\", title: \"$title\", branch: \"$branch\", commit:\"$commit\", updated_at:\"$date\"}]"
+        pr=$(jq -n --arg id "${id}" --arg title "${title}" --arg branch "${branch}" --arg commit "${commit}" --arg date "${date}" '[{id: $id, title: $title, branch: $branch, commit: $commit, updated_at: $date}]')
+        prs=$(jq -n --argjson prs "${prs}" --argjson pr "${pr}"  '$prs + $pr')
     done < <(jq -c '.[]' "${response}")
 
-    if [[ "$prs" == "[]" ]]; then
+    if [[ $(echo "${prs}" | jq length) -eq 0 ]]; then
         jq -n "$prs" >&3
         exit
     fi
 
     # take the list of PRs | filter out containing "wip" in title | sort by update-date of commits | remove the date | pick latest PR, wrap as array for concourse
-    jq --argjson prlist "$(jq -n "$prs")" -n '[ $prlist
+    jq -n --argjson prs "${prs}" '[ $prs
         | map(select(if .title | test("wip"; "i") then false else true end))
         | sort_by(.updated_at)
         | map(del(.updated_at))

--- a/assets/check
+++ b/assets/check
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # vim: set ft=sh
 
-set -e -o pipefail
+set -euo pipefail
 
 exec 3>&1
 exec 1>&2
@@ -10,26 +10,26 @@ payload=$(mktemp /tmp/resource.XXXXXX)
 cat > ${payload} <&0
 
 # source
-bitbucket_type=`jq -r '.source.bitbucket_type // "server"' < ${payload}`
-base_url=`jq -r '.source.base_url // ""' < ${payload}`
-username=`jq -r '.source.username // ""' < ${payload}`
-password=`jq -r '.source.password // ""' < ${payload}`
-project=`jq -r '.source.project // ""' < ${payload}`
-repository=`jq -r '.source.repository // ""' < ${payload}`
-limit=`jq -r '.source.limit // 100' < ${payload}`
-source_branch=`jq -r '.source.branch // ""' < ${payload}`
+bitbucket_type=$(jq -r '.source.bitbucket_type // "server"' < ${payload})
+base_url=$(jq -r '.source.base_url // ""' < ${payload})
+username=$(jq -r '.source.username // ""' < ${payload})
+password=$(jq -r '.source.password // ""' < ${payload})
+project=$(jq -r '.source.project // ""' < ${payload})
+repository=$(jq -r '.source.repository // ""' < ${payload})
+limit=$(jq -r '.source.limit // 100' < ${payload})
+source_branch=$(jq -r '.source.branch // ""' < ${payload})
 # version
-version_updated_at=`jq -r '.version.updated_at // 0' < ${payload}`
+version_updated_at=$(jq -r '.version.updated_at // 0' < ${payload})
 
-if [[ ! ${base_url} ]]; then
+if [[ -z "${base_url}" ]]; then
     echo "error: source.base_url can't be empty"
     exit 1
 fi
-if [[ ! ${project} ]]; then
+if [[ -z "${project}" ]]; then
     echo "error: source.project can't be empty"
     exit 1
 fi
-if [[ ! ${repository} ]]; then
+if [[ -z "${repository}" ]]; then
     echo "error: source.repository can't be empty"
     exit 1
 fi
@@ -37,7 +37,7 @@ fi
 
 # Bitbucket Cloud and (self-hosted) Server APIs are a bit different
 if [[ "$bitbucket_type" == "server" ]]; then
-    [[ "${source_branch}" ]] && branch_param="&at=refs/heads/${source_branch}"
+    [[ -n "${source_branch}" ]] && branch_param="&at=refs/heads/${source_branch}"
     uri="${base_url}/rest/api/1.0/projects/${project}/repos/${repository}/pull-requests?limit=${limit}&state=open${branch_param}"
 
     curl -sS --fail -u ${username}:${password} $uri | jq -r --arg version_updated_at "${version_updated_at}" \
@@ -63,7 +63,7 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
     while read -r pullrequest; do
         branch=$(echo "$pullrequest" | jq -r '.source.branch.name')
         if [[ "${source_branch}" ]]; then
-            [[ "${branch}" = "${source_branch}" ]] || continue
+            [[ "${branch}" == "${source_branch}" ]] || continue
         fi
         id=$(echo "$pullrequest" | jq -r '.id')
         title=$(echo "$pullrequest" | jq -r '.title')
@@ -90,4 +90,3 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
         | map(del(.updated_at))
         | .[-1] ]' >&3
 fi
-

--- a/assets/in
+++ b/assets/in
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # vim: set ft=sh
 
-set -e -o pipefail
+set -euo pipefail
 
 exec 3>&1
 exec 1>&2
@@ -12,31 +12,31 @@ payload=$(mktemp /tmp/resource.XXXXXX)
 cat > "${payload}" <&0
 
 # source
-bitbucket_type=`jq -r '.source.bitbucket_type // "server"' < ${payload}`
-base_url=`jq -r '.source.base_url // ""' < ${payload}`
-username=`jq -r '.source.username // ""' < ${payload}`
-password=`jq -r '.source.password // ""' < ${payload}`
-project=`jq -r '.source.project // ""' < ${payload}`
-repository=`jq -r '.source.repository // ""' < ${payload}`
-git=`jq -r '.source.git // ""' < ${payload}`
+bitbucket_type=$(jq -r '.source.bitbucket_type // "server"' < ${payload})
+base_url=$(jq -r '.source.base_url // ""' < ${payload})
+username=$(jq -r '.source.username // ""' < ${payload})
+password=$(jq -r '.source.password // ""' < ${payload})
+project=$(jq -r '.source.project // ""' < ${payload})
+repository=$(jq -r '.source.repository // ""' < ${payload})
+git=$(jq -r '.source.git // ""' < ${payload})
 # version
-version=`jq -r '.version' < ${payload}`
-version_id=`jq -r '.version.id' < ${payload}`
-version_branch=`jq -r '.version.branch' < ${payload}`
+version=$(jq -r '.version' < ${payload})
+version_id=$(jq -r '.version.id' < ${payload})
+version_branch=$(jq -r '.version.branch' < ${payload})
 
-if [[ ! ${base_url} ]]; then
+if [[ -z "${base_url}" ]]; then
     echo "error: source.base_url can't be empty"
     exit 1
 fi
-if [[ ! ${project} ]]; then
+if [[ -z "${project}" ]]; then
     echo "error: source.project can't be empty"
     exit 1
 fi
-if [[ ! ${repository} ]]; then
+if [[ -z "${repository}" ]]; then
     echo "error: source.repository can't be empty"
     exit 1
 fi
-if [[ ! ${git} ]]; then
+if [[ -z "${git}" ]]; then
     echo "error: source.git can't be empty"
     exit 1
 fi
@@ -46,11 +46,11 @@ if [[ "$bitbucket_type" == "server" ]]; then
 elif [[ "$bitbucket_type" == "cloud" ]]; then
     uri="${base_url}/api/2.0/repositories/${project}/${repository}/pullrequests/${version_id}"
 fi
-pr=`curl -s --fail -u ${username}:${password} $uri`
+pr=$(curl -s --fail -u ${username}:${password} $uri)
 
-git_payload=`echo ${git} | jq --argjson version "${version}" '
+git_payload=$(echo ${git} | jq --argjson version "${version}" '
     {source: (. * {branch: $version.branch})} + {version: {ref: $version.commit}}
-'` 
+')
 
 resource_path="${@%/}"
 echo $git_payload | /opt/git-resource/in ${resource_path} 1>/dev/null
@@ -78,10 +78,10 @@ if [[ "$bitbucket_type" == "server" ]]; then
     cp pull-request-info .git/pr
 
     jq -n --argjson version "${version}" --argjson pr "${pr}" '{
-            version: $version, 
+            version: $version,
             metadata: [
                 {name: "url", value: $pr.links.self[0].href},
-                {name: "author", value: $pr.author.user.displayName}, 
+                {name: "author", value: $pr.author.user.displayName},
                 {name: "commit", value: $version.commit},
                 {name: "feature-branch", value: $version.branch},
                 {name: "upstream-branch", value: $pr.toRef.id}
@@ -106,15 +106,15 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
     cp pull-request-info .git/pr
 
     jq -n --argjson version "${version}" --argjson pr "${pr}" '{
-            version: $version, 
+            version: $version,
             metadata: [
                 {name: "title", value: $pr.title},
                 {name: "url", value: $pr.links.html.href},
-                {name: "author", value: $pr.author.display_name}, 
+                {name: "author", value: $pr.author.display_name},
                 {name: "commit", value: $version.commit},
                 {name: "feature-branch", value: $version.branch},
                 {name: "upstream-branch", value: $pr.destination.branch.name},
                 {name: "pullrequest updated", value: $pr.updated_on}
             ]
         }' >&3
-fi        
+fi

--- a/assets/out
+++ b/assets/out
@@ -64,7 +64,7 @@ change_build_status() {
         }'
     )
 
-    curl --fail \
+    curl -s --fail \
         -u "${username}:${password}" \
         -H "Content-Type: application/json" \
         -XPOST "${url}" \

--- a/assets/out
+++ b/assets/out
@@ -30,7 +30,7 @@ eval_param() {
 }
 
 change_build_status() {
-    if [[ ! "${base_url}" ]]; then
+    if [[ -z "${base_url}" ]]; then
         echo "error: source.base_url can't be empty"
         exit 1
     fi


### PR DESCRIPTION
- Use `jq --arg/--argjson` when building JSON objects in `assets/check`
- `assets/check` isn't given a directory in command line argument (https://concourse-ci.org/implementing-resources.html)
- Make curl silent in `assets/out`
- Shell style changes and fixes to match `assets/out`