### PR TITLE
Add PR title in assets/out output

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -73,6 +73,7 @@ change_build_status() {
     jq -n --argjson pr "${pr}" '{
         version: {
             id: $pr.id|tostring,
+            title: $pr.title,
             branch: $pr.feature_branch,
             commit: $pr.commit
         }
@@ -104,6 +105,7 @@ push() {
         '{
             version: {
                 id: $pr.id|tostring,
+                title: $pr.title,
                 branch: $pr.feature_branch,
                 commit: $git.version.ref
             },


### PR DESCRIPTION
`assets/out` doesn't have the title in its output, causing a new trigger from `assets/check` because this one does include the title, causing Concourse to consider it as a new version of the resource (though that doesn't happen all the time with all repositories for some unknown reason) and triggering a new build for the same revision as a result.

Adding the title in `assets/out`'s output fixes the double-build issue for us.