### PR TITLE
Read PR payload from a file instead of passing it as an argument

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -46,7 +46,8 @@ if [[ "$bitbucket_type" == "server" ]]; then
 elif [[ "$bitbucket_type" == "cloud" ]]; then
     uri="${base_url}/api/2.0/repositories/${project}/${repository}/pullrequests/${version_id}"
 fi
-pr=$(curl -s --fail -u ${username}:${password} $uri)
+pr=$(mktemp /tmp/resource.XXXXXX)
+curl -s --fail -u ${username}:${password} "${uri}" > "${pr}"
 
 git_payload=$(echo ${git} | jq --argjson version "${version}" '
     {source: (. * {branch: $version.branch})} + {version: {ref: $version.commit}}
@@ -59,62 +60,62 @@ echo "pull-request-info" > ${resource_path}/.git/info/exclude
 
 # Bitbucket Cloud and (self-hosted) Server APIs are a bit different
 if [[ "$bitbucket_type" == "server" ]]; then
-    jq -n --argjson version "${version}" --argjson pr "${pr}" '{
-            id: $pr.id,
-            description: $pr.description,
+    jq -n --argjson version "${version}" --slurpfile pr "${pr}" '{
+            id: $pr[0].id,
+            description: $pr[0].description,
             author: {
-                name: $pr.author.user.name,
-                email: $pr.author.user.emailAddress,
-                fullname: $pr.author.user.displayName,
+                name: $pr[0].author.user.name,
+                email: $pr[0].author.user.emailAddress,
+                fullname: $pr[0].author.user.displayName,
             },
             commit: $version.commit,
             feature_branch: $version.branch,
-            title: $pr.title,
-            upstream_branch: $pr.toRef.id,
-            url: $pr.links.self[0].href,
+            title: $pr[0].title,
+            upstream_branch: $pr[0].toRef.id,
+            url: $pr[0].links.self[0].href,
             updated_at: $version.updated_at
         }' > pull-request-info
 
     cp pull-request-info .git/pr
 
-    jq -n --argjson version "${version}" --argjson pr "${pr}" '{
+    jq -n --argjson version "${version}" --slurpfile pr "${pr}" '{
             version: $version,
             metadata: [
-                {name: "url", value: $pr.links.self[0].href},
-                {name: "author", value: $pr.author.user.displayName},
+                {name: "url", value: $pr[0].links.self[0].href},
+                {name: "author", value: $pr[0].author.user.displayName},
                 {name: "commit", value: $version.commit},
                 {name: "feature-branch", value: $version.branch},
-                {name: "upstream-branch", value: $pr.toRef.id}
+                {name: "upstream-branch", value: $pr[0].toRef.id}
             ]
         }' >&3
 elif [[ "$bitbucket_type" == "cloud" ]]; then
-    jq -n --argjson version "${version}" --argjson pr "${pr}" '{
-            id: $pr.id,
-            description: $pr.description,
+    jq -n --argjson version "${version}" --slurpfile pr "${pr}" '{
+            id: $pr[0].id,
+            description: $pr[0].description,
             author: {
-                name: $pr.author.username,
-                fullname: $pr.author.display_name,
+                name: $pr[0].author.username,
+                fullname: $pr[0].author.display_name,
             },
             commit: $version.commit,
             feature_branch: $version.branch,
-            title: $pr.title,
-            upstream_branch: $pr.destination.branch.name,
-            url: $pr.links.html.href,
-            updated_at: $pr.created_on
+            title: $pr[0].title,
+            upstream_branch: $pr[0].destination.branch.name,
+            url: $pr[0].links.html.href,
+            updated_at: $pr[0].created_on
         }' > pull-request-info
 
     cp pull-request-info .git/pr
 
-    jq -n --argjson version "${version}" --argjson pr "${pr}" '{
+    jq -n --argjson version "${version}" --slurpfile pr "${pr}" '{
             version: $version,
             metadata: [
-                {name: "title", value: $pr.title},
-                {name: "url", value: $pr.links.html.href},
-                {name: "author", value: $pr.author.display_name},
+                {name: "title", value: $pr[0].title},
+                {name: "url", value: $pr[0].links.html.href},
+                {name: "author", value: $pr[0].author.display_name},
                 {name: "commit", value: $version.commit},
                 {name: "feature-branch", value: $version.branch},
-                {name: "upstream-branch", value: $pr.destination.branch.name},
-                {name: "pullrequest updated", value: $pr.updated_on}
+                {name: "upstream-branch", value: $pr[0].destination.branch.name},
+                {name: "pullrequest updated", value: $pr[0].updated_on}
             ]
         }' >&3
 fi


### PR DESCRIPTION
Read PR payload from a file instead of passing it as an argument to avoid a crash when the payload is too big (usually a very very long description).

```Identity added: /tmp/git-resource-private-key (/tmp/git-resource-private-key)
Cloning into '/tmp/build/get'...
fetch: Fetching reference HEAD
WARNING: 'git lfs checkout' is deprecated and will be removed in v3.0.0.
'git checkout' has been updated in upstream Git to have comparable speeds
to 'git lfs checkout'.
abcd123 Some commit from a PR with a very long description
/opt/resource/in: line 91: /usr/bin/jq: Argument list too long```