### PR TITLE
Expand variables in url parameter in assets/out

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ jobs:
           params:
             state: SUCCESSFUL
             name: "unit test"
-            url: "http://acme.com/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"      
+            url: "http://acme.com/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
 ```
 
 ## Behavior

--- a/assets/out
+++ b/assets/out
@@ -47,16 +47,17 @@ change_build_status() {
     fi
 
     change_build_status_payload=$(jq -n \
-        --argjson params "${params}" \
         --arg key "$(eval_param '.key // ""')" \
         --arg name "$(eval_param '.name // ""')" \
         --arg description "$(eval_param '.description // ""')" \
+        --arg state "$(eval_param '.state // ""')" \
+        --arg url "$(eval_param '.url // ""')" \
         '{
-            state: $params.state,
+            state: $state,
             key: (if $key != "" then $key else $name end),
             name: ((if $key != "" then $key else $name end) + "-" + env.BUILD_ID),
             url: (
-                $params.url // (
+                $url // (
                     "\(env.ATC_EXTERNAL_URL)/builds/\(env.BUILD_ID)"
                 )
             ),


### PR DESCRIPTION
Taking the example from the README:
```        on_success:
          put: my-repo-with-pull-requests
          params:
            state: SUCCESSFUL
            name: "unit test"
            url: "http://acme.com/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
```

The `$BUILD_*` variables in the `url` parameter stopped being expanded after commit f24e2bc6054e209d60295379d034db2c691bb2cf.