### PR TITLE
fix duplicate pr builds

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -55,7 +55,8 @@ if [[ "$bitbucket_type" == "server" ]]; then
         })
         | map(select(if .title | test("wip"; "i") then false else true end))
         | map(select(.updated_at >= $version_updated_at))
-        | sort_by(.updated_at)' >&3
+        | sort_by(.updated_at)
+        | map(del(.updated_at))' >&3
 elif [[ "$bitbucket_type" == "cloud" ]]; then
     uri="${base_url}/api/2.0/repositories/${project}/${repository}/pullrequests?limit=${limit}&state=OPEN"
 

--- a/assets/out
+++ b/assets/out
@@ -78,8 +78,7 @@ change_build_status() {
             id: $pr.id|tostring,
             title: $pr.title,
             branch: $pr.feature_branch,
-            commit: $pr.commit,
-            updated_at: $pr.updated_at
+            commit: $pr.commit
         },
         metadata: [
             {name: "state", value: $payload.state},
@@ -117,8 +116,7 @@ push() {
                 id: $pr.id|tostring,
                 title: $pr.title,
                 branch: $pr.feature_branch,
-                commit: $git.version.ref,
-                updated_at: $pr.updated_at
+                commit: $git.version.ref
             },
             metadata: $git.metadata
         }' >&3

--- a/assets/out
+++ b/assets/out
@@ -47,15 +47,15 @@ change_build_status() {
     fi
 
     change_build_status_payload=$(jq -n \
-        --arg key "$(eval_param '.key // ""')" \
-        --arg name "$(eval_param '.name // ""')" \
+        --arg key "$(eval_param '.key // env.BUILD_JOB_NAME')" \
+        --arg name "$(eval_param '.name // "\(env.BUILD_JOB_NAME)-\(env.BUILD_ID)"')" \
         --arg description "$(eval_param '.description // ""')" \
         --arg state "$(eval_param '.state // ""')" \
         --arg url "$(eval_param '.url // ""')" \
         '{
             state: $state,
-            key: (if $key != "" then $key else $name end),
-            name: ((if $key != "" then $key else $name end) + "-" + env.BUILD_ID),
+            key: $key,
+            name: $name,
             url: (
                 if $url != "" then
                     $url


### PR DESCRIPTION
we had some duplicated builds as the `check` and `out` resources were returning the always changed `updated_at` metadata.

this (should) has also fixed the description update trigging another build