### PR TITLE
new fetch_upstream param and pass other params to git-resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,16 @@ If any pull request are new or updated or removed, a new version is emitted.
 ### `in`: Fetch the commit that changed the pull request.
 
 This resource delegates entirely to the `in` of the original Git resource, by
+passing through `source.git` to `source` of the original `git-resource`, then
 specifying `source.branch` as the branch that changed, and `version.ref` as the
 commit on the branch.
 
 #### Parameters
 
-All `params` and `source` configuration of the original `git-resource` will be
-respected.
+All `params`, except the ones listed below, will be passed through to `params` of the original `git-resource`.
 
-* `skip_download`: `Optional`. Skip `git pull`. Artifacts based on the git will not be present. 
+* `skip_download`: `Optional`. Skip `git pull`. Artifacts based on the git will not be present.
+* `fetch_upstream`: `Optional`. Also fetch the pull requests' upstream ref. This will overwrite the `fetch` param.
 
 ### `out`: Update the PR.
  

--- a/assets/check
+++ b/assets/check
@@ -69,7 +69,7 @@ if [[ "$bitbucket_type" == "server" ]]; then
     if [[ -n "${paths}" ]]; then
         ids=""
         paths=$(jq -r 'join("|^")' <<< $paths)
-        
+
         for id in $(jq -r '.[].id' <<< "$prs"); do
             uri="${base_url}/rest/api/1.0/projects/${project}/repos/${repository}/pull-requests/${id}/changes?limit=${changes_limit}"
 
@@ -90,6 +90,7 @@ if [[ "$bitbucket_type" == "server" ]]; then
         | map(select(.updated_at >= $version_updated_at))
         | map(select(.title | ascii_downcase | contains("wip") == false))
         | sort_by(.updated_at)
+        | .
         | map(del(.updated_at))' >&3
 elif [[ "$bitbucket_type" == "cloud" ]]; then
     uri="${base_url}/api/2.0/repositories/${project}/${repository}/pullrequests?limit=${limit}&state=OPEN"

--- a/assets/in
+++ b/assets/in
@@ -50,8 +50,8 @@ fi
 pr=$(mktemp /tmp/resource.XXXXXX)
 curl -sL --fail -u "${username}:${password}" "${uri}" > "${pr}"
 
-git_payload=$(echo "${git}" | jq --argjson version "${version}" '
-    {source: (. * {branch: $version.branch})} + {version: {ref: $version.commit}}
+git_payload=$(echo "${git}" | jq --argjson version "${version}" --slurpfile pr "${pr}" '
+    {source: (. * {branch: $version.branch})} + {version: {ref: $version.commit}} + {params: {fetch: [ $pr[0].toRef.id|ltrimstr("refs/heads/") ]}}
 ')
 
 resource_path="${@%/}"

--- a/assets/in
+++ b/assets/in
@@ -19,6 +19,7 @@ password="$(jq -r '.source.password // ""' < "${payload}")"
 project="$(jq -r '.source.project // ""' < "${payload}")"
 repository="$(jq -r '.source.repository // ""' < "${payload}")"
 git="$(jq -r '.source.git // ""' < "${payload}")"
+submodule_recursive="$(jq -r '.params.submodule_recursive // true' < "${payload}")"
 # params
 skip_download="$(jq -r '.params.skip_download // false' < "${payload}")"
 # version
@@ -50,8 +51,15 @@ fi
 pr=$(mktemp /tmp/resource.XXXXXX)
 curl -sL --fail -u "${username}:${password}" "${uri}" > "${pr}"
 
-git_payload=$(echo "${git}" | jq --argjson version "${version}" --slurpfile pr "${pr}" '
-    {source: (. * {branch: $version.branch})} + {version: {ref: $version.commit}} + {params: {fetch: [ $pr[0].toRef.id|ltrimstr("refs/heads/") ]}}
+git_payload=$(echo "${git}" | jq --argjson version "${version}" --slurpfile pr "${pr}" --arg recur "${submodule_recursive}" '
+    {source: (. * {branch: $version.branch})}
+    + {version: {ref: $version.commit}}
+    + {
+        params: {
+          fetch: [ $pr[0].toRef.id|ltrimstr("refs/heads/") ],
+          submodule_recursive: $recur
+        }
+      }
 ')
 
 resource_path="${@%/}"

--- a/assets/in
+++ b/assets/in
@@ -19,9 +19,10 @@ password="$(jq -r '.source.password // ""' < "${payload}")"
 project="$(jq -r '.source.project // ""' < "${payload}")"
 repository="$(jq -r '.source.repository // ""' < "${payload}")"
 git="$(jq -r '.source.git // ""' < "${payload}")"
-submodule_recursive="$(jq -r '.params.submodule_recursive // true' < "${payload}")"
 # params
 skip_download="$(jq -r '.params.skip_download // false' < "${payload}")"
+fetch_upstream="$(jq -r '.params.fetch_upstream // false' < "${payload}")"
+git_params="$(jq -r '.params | del(.skip_download) | del(.fetch_upstream) // {}' < "${payload}")"
 # version
 version="$(jq -r '.version' < "${payload}")"
 version_id="$(jq -r '.version.id' < "${payload}")"
@@ -51,16 +52,21 @@ fi
 pr=$(mktemp /tmp/resource.XXXXXX)
 curl -sL --fail -u "${username}:${password}" "${uri}" > "${pr}"
 
-git_payload=$(echo "${git}" | jq --argjson version "${version}" --slurpfile pr "${pr}" --arg recur "${submodule_recursive}" '
-    {source: (. * {branch: $version.branch})}
-    + {version: {ref: $version.commit}}
-    + {
-        params: {
-          fetch: [ $pr[0].toRef.id|ltrimstr("refs/heads/") ],
-          submodule_recursive: $recur
-        }
-      }
+git_payload=$(echo "${git}" | jq --argjson version "${version}" --argjson params "${git_params}" '
+    {source: (. * {branch: $version.branch})} + {version: {ref: $version.commit}} + {params: $params}
 ')
+
+if [[ "${fetch_upstream}" != "false" ]]; then
+    if [[ "$bitbucket_type" == "server" ]]; then
+        git_payload=$(echo "${git_payload}" | jq --slurpfile pr "${pr}" '
+            . * { params: { fetch: [ $pr[0].toRef.id|ltrimstr("refs/heads/") ] } }
+        ')
+    elif [[ "$bitbucket_type" == "cloud" ]]; then
+        git_payload=$(echo "${git_payload}" | jq --slurpfile pr "${pr}" '
+            . * { params: { fetch: [ $pr[0].destination.branch.name|ltrimstr("refs/heads/") ] } }
+        ')
+    fi
+fi
 
 resource_path="${@%/}"
 if [[ "${skip_download}" = "false" ]]; then


### PR DESCRIPTION
1. `in`: `params.fetch_upstream: true` will determine and fetch the pull-request's upstream branch to enable diffs or other behavior by subsequent tasks
2. `in`: `params` other than `fetch_upstream` and `skip_download` are passed through to the git-resource