### PR TITLE
Fix credentials not being quoted

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -73,7 +73,7 @@ if [[ "$bitbucket_type" == "server" ]]; then
         for id in $(jq -r '.[].id' <<< "$prs"); do
             uri="${base_url}/rest/api/1.0/projects/${project}/repos/${repository}/pull-requests/${id}/changes?limit=${changes_limit}"
 
-            changes=$(curl -sSL --fail -u ${username}:${password} "${uri}" \
+            changes=$(curl -sSL --fail -u "${username}:${password}" "${uri}" \
                 | jq --arg paths ^$paths '.values | map(.path.parent) | map(select(test($paths))) | any')
             [[ $changes != false ]] && ids+="${id},"
         done


### PR DESCRIPTION
When using the `paths` option, the request could fail because the credentials were not wrapped in quotes.

Fixes #43