### PR TITLE
Return no results if filter on path if no prs changed instead of all prs

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -80,6 +80,8 @@ if [[ "$bitbucket_type" == "server" ]]; then
 
         if [[ -n ${ids} ]]; then
             prs=$(jq --argjson ids [${ids::-1}] 'map(select( .id as $in | $ids | index($in | tonumber)))' <<< "$prs")
+        else
+            prs="[]"
         fi
     fi
 


### PR DESCRIPTION
When using this resource, if a `paths` filter is used but no PRs currently have changes to that path, all prs are returned. I believe the correct behavior should instead be that no prs should be returned. 