### PR TITLE
add `direction` source parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ from the original resource is ignored.
 * `branch`: *Optional*. if given, only pull requests against this branch will be checked
 * `paths`: *Optional*. if specified (as a list of glob patterns), only changes to the specified files will yield new versions from check
 * `changes_limit`: *Optional*. the maximum number of changed `paths` loaded for each pull-request. `default: 100`. It works only with the `paths` parameter.
-
+* `direction`: *Optional*. the direction relative to the specified repository, either `incoming` (destination, e.g. to master) or `outgoing` (source, e.g. from feature).
 
 ### Example
 

--- a/assets/check
+++ b/assets/check
@@ -20,6 +20,7 @@ limit=$(jq -r '.source.limit // 100' < ${payload})
 changes_limit=$(jq -r '.source.changes_limit // 100' < ${payload})
 source_branch=$(jq -r '.source.branch // ""' < ${payload})
 paths=$(jq -r '.source.paths // ""' < ${payload})
+direction=$(jq -r '.source.direction // ""' < ${payload})
 
 # version
 version_updated_at=$(jq -r '.version.updated_at // 0' < ${payload})
@@ -50,11 +51,17 @@ if [[ "$bitbucket_type" == "server" ]]; then
         branch_param=""
     fi
 
+    if [[ -n "${direction}" ]]; then
+        direction_param="&direction=${direction}"
+    else
+        direction_param=""
+    fi
+
     if [[ -f /tmp/pr-last-updated-at ]]; then
         version_updated_at=$(cat /tmp/pr-last-updated-at)
     fi
 
-    prs=$(request "/pull-requests?limit=${limit}&state=open${branch_param}" \
+    prs=$(request "/pull-requests?limit=${limit}&state=open${branch_param}${direction_param}" \
         | jq '
             .values
             | map({
@@ -101,9 +108,15 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
     response=$(mktemp /tmp/resource.XXXXXX)
     curl -sSL --fail -u "${username}:${password}" $uri | jq -r '.values' > "${response}"
 
+    if [[ "${direction}" == "incoming" ]]; then
+        branch_object="destination"
+    else
+        branch_object="source"
+    fi
+
     prs="[]"
     while read -r pullrequest; do
-        branch=$(echo "$pullrequest" | jq -r '.source.branch.name')
+        branch=$(echo "$pullrequest" | jq -r ".${branch_object}.branch.name")
         if [[ "${source_branch}" ]]; then
             [[ "${branch}" == "${source_branch}" ]] || continue
         fi


### PR DESCRIPTION
this resource's defaults for source (incoming) vs. destination (outgoing) repo/branch are opposite for cloud vs. server.

server has a `direction` query param, which defaults to `incoming` corresponding to destination.
the resource's cloud code path was using .source.branch.name, which corresponds to source.

this change allows unconfigured `direction` to continue old resource behavior for backwards compatibility, while also allowing the user to specify `incoming`/`outgoing` as needed.

see: https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/pullrequests#get
see: https://docs.atlassian.com/bitbucket-server/rest/7.2.4/bitbucket-rest.html#idp280