### PR TITLE
Fix Bitbucket Cloud api endpoints

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -112,7 +112,7 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
         curl -XPOST -sSL --fail -u "${oauth_id}:${oauth_secret}" -d grant_type=client_credentials $uri | jq -r '.access_token' > "${oauth_response}"
         authentication=(-H "Authorization: Bearer `cat $oauth_response`")
     fi
-    uri="${base_url}/api/2.0/repositories/${project}/${repository}/pullrequests?limit=${limit}&state=OPEN"
+    uri="${base_url}/2.0/repositories/${project}/${repository}/pullrequests?limit=${limit}&state=OPEN"
 
     # write response to file as feeding it to jq from a variable doesnt work properly: JSON looses linefeed format in variable
     response=$(mktemp /tmp/resource.XXXXXX)

--- a/assets/in
+++ b/assets/in
@@ -57,7 +57,7 @@ fi
 if [[ "$bitbucket_type" == "server" ]]; then
     uri="${base_url}/rest/api/1.0/projects/${project}/repos/${repository}/pull-requests/${version_id}"
 elif [[ "$bitbucket_type" == "cloud" ]]; then
-    uri="${base_url}/api/2.0/repositories/${project}/${repository}/pullrequests/${version_id}"
+    uri="${base_url}/2.0/repositories/${project}/${repository}/pullrequests/${version_id}"
 fi
 
 pr=$(mktemp /tmp/resource.XXXXXX)

--- a/assets/out
+++ b/assets/out
@@ -42,7 +42,7 @@ change_build_status() {
     if [[ "${bitbucket_type}" == "server" ]]; then
         url="${base_url}/rest/build-status/1.0/commits/${commit}"
     elif [[ "${bitbucket_type}" == "cloud" ]]; then
-        url="${base_url}/api/2.0/repositories/${project}/${repository}/commit/${commit}/statuses/build"
+        url="${base_url}/2.0/repositories/${project}/${repository}/commit/${commit}/statuses/build"
     else
         echo "error: incorrect bitbucket server type '${bitbucket_type}'"
         exit 1


### PR DESCRIPTION
This PR fixes #37.

Latest documentation lists the correct URI format as: `https://api.bitbucket.org/2.0/...`

https://developer.atlassian.com/bitbucket/api/2/reference/