### PR TITLE
prevent new versions when only the pull request title changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Or:
 * `oauth_id`: *Required*. Oauth id of an OAuth consumer configured as private and with permission to write to PRs.
 * `oauth_secret`: *Required*. Oauth secret of the same consumer.
 
+* `exclude_title`: *Optional*. prevent *check* from emitting new versions when only the pull request title changes, except when the string "WIP" is removed from the title.
 
 ### Example
 

--- a/assets/check
+++ b/assets/check
@@ -23,6 +23,7 @@ paths=$(jq -r '.source.paths // ""' < ${payload})
 direction=$(jq -r '.source.direction // ""' < ${payload})
 oauth_id=$(jq -r '.source.oauth_id // ""' < ${payload})
 oauth_secret=$(jq -r '.source.oauth_secret // ""' < ${payload})
+exclude_title=$(jq -r '.source.exclude_title // "false"' < ${payload})
 
 # version
 version_updated_at=$(jq -r '.version.updated_at // 0' < ${payload})
@@ -96,10 +97,11 @@ if [[ "$bitbucket_type" == "server" ]]; then
 
     echo "${prs}" | jq -r 'first | .updated_at' > /tmp/pr-last-updated-at
 
-    echo "${prs}" | jq --argjson version_updated_at "${version_updated_at}" '
+    echo "${prs}" | jq --argjson version_updated_at "${version_updated_at}" --argjson exclude_title "${exclude_title}" '
         map(. + {updated_at: .updated_at|tonumber})
         | map(select(.updated_at >= $version_updated_at))
         | map(select(.title | ascii_downcase | contains("wip") == false))
+        | if $exclude_title then map(del(.title)) else . end
         | sort_by(.updated_at)
         | .
         | map(del(.updated_at))' >&3
@@ -150,6 +152,7 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
     # take the list of PRs | filter out containing "wip" in title | sort by update-date of commits | remove the date | pick latest PR, wrap as array for concourse
     jq -n --argjson prs "${prs}" '[ $prs
         | map(select(if .title | test("wip"; "i") then false else true end))
+        | if $exclude_title then map(del(.title)) else . end
         | sort_by(.updated_at)
         | map(del(.updated_at))
         | .[-1] ]' >&3


### PR DESCRIPTION
add `exclude_title` source config to prevent *check* from emitting new versions when only the pull request title changes