### PR TITLE
Fix Bitbucket cloud bugs and add Paths feature

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -148,13 +148,16 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
     if [[ -n "${paths}" ]]; then
         ids=""
         paths=$(jq -r 'join("|^")' <<< $paths)
+        diffstat_response=$(mktemp /tmp/diffstat_response.XXXXXX)
 
         for id in $(jq -r '.[].id' <<< "$prs"); do
             uri="${base_url}/2.0/repositories/${project}/${repository}/pullrequests/${id}/diffstat"
 
-            changes=$(curl -sSL --fail "${authentication[@]}" "${uri}" \
-                 | jq --arg paths ^$paths '.values | map(.new.path) | map(select(test($paths))) | any')
-            [[ $changes != false ]] && ids+="${id},"
+            curl -sSL --fail "${authentication[@]}" "${uri}" >"${diffstat_response}"
+
+            new_changes=$(jq --arg paths ^$paths '[.values[] | select(.new.path != null)] | map(.new.path) | map(select(test($paths))) | any' "${diffstat_response}")
+            old_changes=$(jq --arg paths ^$paths '[.values[] | select(.old.path != null)] | map(.old.path) | map(select(test($paths))) | any' "${diffstat_response}")
+            [[ $new_changes != false || $old_changes != false ]] && ids+="${id},"
         done
 
         if [[ -n ${ids} ]]; then

--- a/assets/check
+++ b/assets/check
@@ -127,12 +127,13 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
 
     prs="[]"
     while read -r pullrequest; do
-        branch=$(echo "$pullrequest" | jq -r ".${branch_object}.branch.name")
         if [[ "${source_branch}" ]]; then
-            [[ "${branch}" == "${source_branch}" ]] || continue
+            [[ "$(echo "$pullrequest" | jq -r ".${branch_object}.branch.name")" == "${source_branch}" ]] || continue
         fi
+
         id=$(echo "$pullrequest" | jq -r '.id')
         title=$(echo "$pullrequest" | jq -r '.title')
+        branch=$(echo "$pullrequest" | jq -r ".source.branch.name")
         commit=$(echo "$pullrequest" | jq -r '.source.commit.hash')
         commit_url=$(echo "$pullrequest" | jq -r '.source.commit.links.self.href')
 
@@ -144,13 +145,32 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
         prs=$(jq -n --argjson prs "${prs}" --argjson pr "${pr}"  '$prs + $pr')
     done < <(jq -c '.[]' "${response}")
 
+    if [[ -n "${paths}" ]]; then
+        ids=""
+        paths=$(jq -r 'join("|^")' <<< $paths)
+
+        for id in $(jq -r '.[].id' <<< "$prs"); do
+            uri="${base_url}/2.0/repositories/${project}/${repository}/pullrequests/${id}/diffstat"
+
+            changes=$(curl -sSL --fail "${authentication[@]}" "${uri}" \
+                 | jq --arg paths ^$paths '.values | map(.new.path) | map(select(test($paths))) | any')
+            [[ $changes != false ]] && ids+="${id},"
+        done
+
+        if [[ -n ${ids} ]]; then
+            prs=$(jq --argjson ids [${ids::-1}] 'map(select( .id as $in | $ids | index($in | tonumber)))' <<< "$prs")
+        else
+            prs="[]"
+        fi
+    fi
+
     if [[ $(echo "${prs}" | jq length) -eq 0 ]]; then
         jq -n "$prs" >&3
         exit
     fi
 
     # take the list of PRs | filter out containing "wip" in title | sort by update-date of commits | remove the date | pick latest PR, wrap as array for concourse
-    jq -n --argjson prs "${prs}" '[ $prs
+    jq -n --argjson prs "${prs}" --argjson exclude_title "${exclude_title}" '[ $prs
         | map(select(if .title | test("wip"; "i") then false else true end))
         | if $exclude_title then map(del(.title)) else . end
         | sort_by(.updated_at)


### PR DESCRIPTION
When using bitbucket cloud the direction source parameters was making
the resulting version to not always use the correct branch, which would
then fail in the `get` step because the commit was not found in the
branch.

The feature to add exclude_title was not adding the variable to the jq
call.

Added ability to filter PR based on paths, fixes #58