### PR TITLE
Fix: don't remove --insecure when no ca cert

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -54,8 +54,6 @@ fi
 # Check for SSL CA Cert
 if [[ -z "$ssl_cacert" ]]; then
     ssl_flag="--cacert ${ssl_cacert}"
-else
-    ssl_flag=""
 fi
 
 # Bitbucket Cloud and (self-hosted) Server APIs are a bit different
@@ -63,9 +61,9 @@ if [[ "$bitbucket_type" == "server" ]]; then
     request() {
         uri="${base_url}/rest/api/1.0/projects/${project}/repos/${repository}${1}"
         if [[ -n "${access_token}" ]]; then
-            curl -sSL "${ssl_flag}" --fail -H "Authorization: Bearer ${access_token}" "$uri"
+            curl -sSL ${ssl_flag} --fail -H "Authorization: Bearer ${access_token}" "$uri"
         else
-            curl -sSL "${ssl_flag}" --fail -u "${username}:${password}" "$uri"
+            curl -sSL ${ssl_flag} --fail -u "${username}:${password}" "$uri"
         fi
     }
 
@@ -130,14 +128,14 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
     if [[ -n "${oauth_id}" ]]; then
         oauth_response=$(mktemp /tmp/resource.XXXXXX)
         uri="${base_url}/site/oauth2/access_token"
-        curl -XPOST -sSL "${ssl_flag}" --fail -u "${oauth_id}:${oauth_secret}" -d grant_type=client_credentials $uri | jq -r '.access_token' > "${oauth_response}"
+        curl -XPOST -sSL ${ssl_flag} --fail -u "${oauth_id}:${oauth_secret}" -d grant_type=client_credentials $uri | jq -r '.access_token' > "${oauth_response}"
         authentication=(-H "Authorization: Bearer `cat $oauth_response`")
     fi
     uri="${base_url}/2.0/repositories/${project}/${repository}/pullrequests?limit=${limit}&state=OPEN"
 
     # write response to file as feeding it to jq from a variable doesnt work properly: JSON looses linefeed format in variable
     response=$(mktemp /tmp/resource.XXXXXX)
-    curl -sSL "${ssl_flag}" --fail "${authentication[@]}" $uri | jq -r ".values[0:$limit]" > "${response}"
+    curl -sSL ${ssl_flag} --fail "${authentication[@]}" $uri | jq -r ".values[0:$limit]" > "${response}"
     if [[ "${direction}" == "incoming" ]]; then
         branch_object="destination"
     else
@@ -172,7 +170,7 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
         for id in $(jq -r '.[].id' <<< "$prs"); do
             uri="${base_url}/2.0/repositories/${project}/${repository}/pullrequests/${id}/diffstat"
 
-            curl -sSL "${ssl_flag}" --fail "${authentication[@]}" "${uri}" >"${diffstat_response}"
+            curl -sSL ${ssl_flag} --fail "${authentication[@]}" "${uri}" >"${diffstat_response}"
 
             new_changes=$(jq --arg paths ^$paths '[.values[] | select(.new.path != null)] | map(.new.path) | map(select(test($paths))) | any' "${diffstat_response}")
             old_changes=$(jq --arg paths ^$paths '[.values[] | select(.old.path != null)] | map(.old.path) | map(select(test($paths))) | any' "${diffstat_response}")

--- a/assets/in
+++ b/assets/in
@@ -77,12 +77,10 @@ fi
 # Check for SSL CA Cert
 if [[ -z "$ssl_cacert" ]]; then
     ssl_flag="--cacert ${ssl_cacert}"
-else
-    ssl_flag=""
 fi
 
 pr=$(mktemp /tmp/resource.XXXXXX)
-curl -sL "${ssl_flag}" --fail "${authentication[@]}" "${uri}" > "${pr}"
+curl -sL ${ssl_flag} --fail "${authentication[@]}" "${uri}" > "${pr}"
 
 git_payload=$(echo "${git}" | jq --argjson version "${version}" --argjson params "${git_params}" '
     {source: (. * {branch: $version.branch})} + {version: {ref: $version.commit}} + {params: $params}

--- a/assets/out
+++ b/assets/out
@@ -82,8 +82,6 @@ change_build_status() {
     # Check for SSL CA Cert
     if [[ -z "$ssl_cacert" ]]; then
         ssl_flag="--cacert ${ssl_cacert}"
-    else
-        ssl_flag=""
     fi
 
     if [[ -n "${access_token}" ]]; then
@@ -94,12 +92,12 @@ change_build_status() {
     if [[ -n "${oauth_id}" ]]; then
         oauth_response=$(mktemp /tmp/resource.XXXXXX)
         uri="${base_url}/site/oauth2/access_token"
-        curl -XPOST -sSL "${ssl_flag}" --fail -u "${oauth_id}:${oauth_secret}" -d grant_type=client_credentials $uri | jq -r '.access_token' > "${oauth_response}"
+        curl -XPOST -sSL ${ssl_flag} --fail -u "${oauth_id}:${oauth_secret}" -d grant_type=client_credentials $uri | jq -r '.access_token' > "${oauth_response}"
         authentication=(-H "Authorization: Bearer `cat $oauth_response`")
     fi
 
     curl -sL --fail \
-        "${ssl_flag}" \
+        ${ssl_flag} \
         "${authentication[@]}" \
         -H "Content-Type: application/json" \
         -XPOST "${url}" \


### PR DESCRIPTION
This is a follow up to #61. When testing my branch from that PR I discovered that passing ca certificates worked on my new pipeline but the `skip ssl verification` option was broken on my other pipeline. I had made the changes in the PR on my local system but forgot to update my existing PR. 

During testing I also discovered that the `ssl_flag` variable does not need quotes when interpolating in `curl` commands.
