### PR TITLE
fix: bitbucket cloud usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,3 @@ RUN mv /opt/resource /opt/git-resource
 
 ADD assets/ /opt/resource/
 RUN chmod +x /opt/resource/*
-

--- a/assets/check
+++ b/assets/check
@@ -30,7 +30,9 @@ ssl_cacert=$(jq -r '.source.ssl_cacert // ""' < ${payload})
 
 # version
 version_updated_at=$(jq -r '.version.updated_at // 0' < ${payload})
-
+if [[ "$bitbucket_type" == "cloud" ]]; then
+      base_url="https://api.bitbucket.org"
+fi
 if [[ -z "${base_url}" ]]; then
     echo "error: source.base_url can't be empty"
     exit 1
@@ -52,7 +54,7 @@ else
 fi
 
 # Check for SSL CA Cert
-if [[ -z "$ssl_cacert" ]]; then
+if [[ -n "${ssl_cacert}" ]]; then
     ssl_flag="--cacert ${ssl_cacert}"
 fi
 
@@ -127,7 +129,7 @@ elif [[ "$bitbucket_type" == "cloud" ]]; then
 
     if [[ -n "${oauth_id}" ]]; then
         oauth_response=$(mktemp /tmp/resource.XXXXXX)
-        uri="${base_url}/site/oauth2/access_token"
+        uri="https://bitbucket.org/site/oauth2/access_token"
         curl -XPOST -sSL ${ssl_flag} --fail -u "${oauth_id}:${oauth_secret}" -d grant_type=client_credentials $uri | jq -r '.access_token' > "${oauth_response}"
         authentication=(-H "Authorization: Bearer `cat $oauth_response`")
     fi

--- a/assets/in
+++ b/assets/in
@@ -32,6 +32,9 @@ git_params="$(jq -r '.params | del(.skip_download) | del(.fetch_upstream) // {}'
 version="$(jq -r '.version' < "${payload}")"
 version_id="$(jq -r '.version.id' < "${payload}")"
 
+if [[ "$bitbucket_type" == "cloud" ]]; then
+      base_url="https://api.bitbucket.org"
+fi
 if [[ -z "${base_url}" ]]; then
     echo "error: source.base_url can't be empty"
     exit 1
@@ -57,6 +60,9 @@ fi
 if [[ -n "${oauth_id}" ]]; then
     oauth_response=$(mktemp /tmp/resource.XXXXXX)
     uri="${base_url}/site/oauth2/access_token"
+    if [[ "$bitbucket_type" == "cloud" ]]; then
+      uri="https://bitbucket.org/site/oauth2/access_token"
+    fi
     curl -XPOST -sSL --fail -u "${oauth_id}:${oauth_secret}" -d grant_type=client_credentials $uri | jq -r '.access_token' > "${oauth_response}"
     authentication=(-H "Authorization: Bearer `cat $oauth_response`")
 fi
@@ -75,7 +81,7 @@ else
 fi
 
 # Check for SSL CA Cert
-if [[ -z "$ssl_cacert" ]]; then
+if [[ -n "${ssl_cacert}" ]]; then
     ssl_flag="--cacert ${ssl_cacert}"
 fi
 

--- a/assets/out
+++ b/assets/out
@@ -30,6 +30,10 @@ ssl_cacert=$(jq -r '.source.ssl_cacert // ""' < ${payload})
 path="$(realpath "${PWD}"/"${path}")/"
 pr=$(cat "${path}.git/pr")
 
+if [[ "$bitbucket_type" == "cloud" ]]; then
+      base_url="https://api.bitbucket.org"
+fi
+
 eval_param() {
     eval echo "$(jq -r "${1}" <<< "${params}")"
 }
@@ -80,7 +84,7 @@ change_build_status() {
     fi
 
     # Check for SSL CA Cert
-    if [[ -z "$ssl_cacert" ]]; then
+    if [[ -n "${ssl_cacert}" ]]; then
         ssl_flag="--cacert ${ssl_cacert}"
     fi
 
@@ -92,6 +96,9 @@ change_build_status() {
     if [[ -n "${oauth_id}" ]]; then
         oauth_response=$(mktemp /tmp/resource.XXXXXX)
         uri="${base_url}/site/oauth2/access_token"
+        if [[ "$bitbucket_type" == "cloud" ]]; then
+             uri="https://bitbucket.org/site/oauth2/access_token"
+        fi
         curl -XPOST -sSL ${ssl_flag} --fail -u "${oauth_id}:${oauth_secret}" -d grant_type=client_credentials $uri | jq -r '.access_token' > "${oauth_response}"
         authentication=(-H "Authorization: Bearer `cat $oauth_response`")
     fi

--- a/debug.sh
+++ b/debug.sh
@@ -15,5 +15,5 @@ if [ -z "${script}" ]; then
 fi
 
 docker build -t concourse-git-bitbucket-pr-resource:dev .
-docker run --rm -i -v "${PWD}/.tmp:/tmp/resource" concourse-git-bitbucket-pr-resource:dev \
+docker run --rm -i --platform linux/amd64 -v "${PWD}/.tmp:/tmp/resource" concourse-git-bitbucket-pr-resource:dev \
     bash "${BASH_OPTS:-+x}" "/opt/resource/${script}" "/tmp/resource" <<< "$(cat)"


### PR DESCRIPTION
 - Oauth credentials usage was broken: different url is required for oauth flow than for api
 - Removed need for url parameter if type is == "cloud"
 - CA cert usage in CURL was broken due to if using -z instead of -n: Only appended certificate if string was empty (typo?)
 - Enforce linux/amd64 platform in debug script, to allow arm to use it also (e.g. M1 processors)